### PR TITLE
Enable gzip compression

### DIFF
--- a/bin/ember-fastboot
+++ b/bin/ember-fastboot
@@ -35,7 +35,8 @@ var notifier = {
 
 var server = new FastBootAppServer({
   distPath: distPath,
-  notifier: notifier
+  notifier: notifier,
+  gzip: true
 });
 
 console.log('Booting Ember app...');


### PR DESCRIPTION
Since the Heroku Ember.js buildpack [installs `fastboot-cli`](https://github.com/heroku/heroku-buildpack-ember-cli-deploy/blob/master/buildpack/mrblib/buildpack/commands/compile.rb#L61-L64) to run the FastBoot server, merging this PR would add gzip support to all Heroku FastBoot apps once they recompile their slugs. Let me know if it should have a command line option to disable it or something.